### PR TITLE
Fix documentation about Str footprint on 64bit arch

### DIFF
--- a/Str.h
+++ b/Str.h
@@ -57,7 +57,7 @@
 #endif
 
 // This is the base class that you can pass around
-// Footprint is 8-bytes (32-bits arch) or 12-bytes (64-bits arch)
+// Footprint is 8-bytes (32-bits arch) or 16-bytes (64-bits arch)
 class Str
 {
     char*               Data;                   // Point to LocalBuf() or heap allocated


### PR DESCRIPTION
sizeof(Str) is 16 bytes not 12 on x86-64, because char* has 8 byte alignment, forcing the 12 byte struct to be rounded up to 16 bytes (multiple of 8)