### PR TITLE
STR_API and natvis

### DIFF
--- a/Str.h
+++ b/Str.h
@@ -93,6 +93,9 @@ TODO
 #define STR_ASSERT    assert
 #include <assert.h>
 #endif
+#ifndef STR_API
+#define STR_API
+#endif
 #include <stdarg.h>   // for va_list
 
 // Configuration: #define STR_SUPPORT_STD_STRING 0 to disable setters variants using const std::string& (on by default)
@@ -107,7 +110,7 @@ TODO
 
 // This is the base class that you can pass around
 // Footprint is 8-bytes (32-bits arch) or 16-bytes (64-bits arch)
-class Str
+class STR_API Str
 {
     char*               Data;                   // Point to LocalBuf() or heap allocated
     int                 Capacity : 21;          // Max 2 MB

--- a/Str.natvis
+++ b/Str.natvis
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+
+<Type Name="Str">
+  <DisplayString>{ Data, na }</DisplayString>
+  <Expand>
+    <Item Name="Data">Data, na</Item>
+    <Item Name="Size">strlen(Data)</Item>
+    <Item Name="Capacity">Capacity</Item>
+  </Expand>
+</Type>
+
+</AutoVisualizer>


### PR DESCRIPTION
I added STR_API for wrapping DLL export/import declspecs on Windows and a basic natvis file (showing Data/Size/Capacity).