### PR TITLE
Fixed bugs when modifying a non-owned string

### DIFF
--- a/Str.cpp
+++ b/Str.cpp
@@ -12,7 +12,7 @@
 #endif
 
 #include "Str.h"
-#include <string.h>
+#include <stdio.h> // for vsnprintf
 
 // On some platform vsnprintf() takes va_list by reference and modifies it.
 // va_copy is the 'correct' way to copy a va_list but Visual Studio prior to 2013 doesn't have it.

--- a/Str.h
+++ b/Str.h
@@ -64,7 +64,7 @@ All StrXXX types derives from Str and instance hold the local buffer capacity. S
 
 /*
  CHANGELOG
-  0.29 - fixed bug when calling reserve on non-owned strings (ie. when using StrRef or set_ref).
+  0.29 - fixed bug when calling reserve on non-owned strings (ie. when using StrRef or set_ref), and fixed <string> include.
   0.28 - breaking change: replaced Str32 by Str30 to avoid collision with Str32 from MacTypes.h .
   0.27 - added STR_API and basic natvis file.
   0.26 - fixed set(cont char* src, const char* src_end) writing null terminator to the wrong position.
@@ -100,6 +100,7 @@ TODO
 #define STR_API
 #endif
 #include <stdarg.h>   // for va_list
+#include <string.h>   // for strlen, strcmp, memcpy, etc.
 
 // Configuration: #define STR_SUPPORT_STD_STRING 0 to disable setters variants using const std::string& (on by default)
 #ifndef STR_SUPPORT_STD_STRING
@@ -111,9 +112,8 @@ TODO
 #define STR_DEFINE_STR32 0
 #endif
 
-#ifdef STR_SUPPORT_STD_STRING
+#if STR_SUPPORT_STD_STRING
 #include <string>
-#include <string.h>
 #endif
 
 // This is the base class that you can pass around

--- a/Str.h
+++ b/Str.h
@@ -263,30 +263,21 @@ Str::Str()
 }
 
 Str::Str(const Str& rhs)
+    : Str()
 {
-    Data = EmptyBuffer;
-    Capacity = 0;
-    LocalBufSize = 0;
-    Owned = 0;
     set(rhs);
 }
 
 Str::Str(const char* rhs)
+    : Str()
 {
-    Data = EmptyBuffer;
-    Capacity = 0;
-    LocalBufSize = 0;
-    Owned = 0;
     set(rhs);
 }
 
 #if STR_SUPPORT_STD_STRING
 Str::Str(const std::string& rhs)
+    : Str()
 {
-    Data = EmptyBuffer;
-    Capacity = 0;
-    LocalBufSize = 0;
-    Owned = 0;
     set(rhs);
 }
 #endif

--- a/Str.h
+++ b/Str.h
@@ -64,6 +64,7 @@ All StrXXX types derives from Str and instance hold the local buffer capacity. S
 
 /*
  CHANGELOG
+  0.29 - fixed bug when calling reserve on non-owned strings (ie. when using StrRef or set_ref).
   0.28 - breaking change: replaced Str32 by Str30 to avoid collision with Str32 from MacTypes.h .
   0.27 - added STR_API and basic natvis file.
   0.26 - fixed set(cont char* src, const char* src_end) writing null terminator to the wrong position.


### PR DESCRIPTION
- Reserve functions now correctly set the Owned flag if they allocate a buffer. Append/set functions now rely on that instead of changing the Owned flag themselves. Also fixed a bug where calling reserve on a StrRef could overflow the buffer.

- Fixed string includes. #ifdef instead of #if meant <string> was always included. <string.h> is always needed however, and should not be inside the ifdef.

