### PR TITLE
Fix MSVC security warning

### DIFF
--- a/Str.h
+++ b/Str.h
@@ -386,11 +386,6 @@ STR_DEFINETYPE_F(Str32, Str32f)
 
 #ifdef STR_IMPLEMENTATION
 
-
-#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
-#define _CRT_SECURE_NO_WARNINGS
-#endif
-
 #include <stdio.h> // for vsnprintf
 
 // On some platform vsnprintf() takes va_list by reference and modifies it.
@@ -443,7 +438,11 @@ void    Str::reserve(int new_capacity)
     }
 
     // string in Data might be longer than new_capacity if it wasn't owned, don't copy too much
+#ifdef _MSC_VER
+    strncpy_s(new_data, (size_t)new_capacity, Data, (size_t)new_capacity - 1);
+#else
     strncpy(new_data, Data, (size_t)new_capacity - 1);
+#endif
     new_data[new_capacity - 1] = 0;
 
     if (Owned && !is_using_local_buf())


### PR DESCRIPTION
I think this broke when converting the lib to single-header. Now, `<string.h>` is included at the top of the file, before the definition of `_CRT_SECURE_NO_WARNINGS` in the implementation section, so the call to `strncpy()` now generates a warning. We shouldn't move the definition of `_CRT_SECURE_NO_WARNINGS` up to the header section, as it could then affect other code in the user's project.

That call to `strncpy()` is the one and only place in the lib that generates a security warning, so I opted to just `#ifdef` around it and use `strncpy_s()` for MSVC.